### PR TITLE
Fix interprocess message mismatch

### DIFF
--- a/zero_downtime.js
+++ b/zero_downtime.js
@@ -9,7 +9,7 @@ var cluster = require('cluster'),
 
 		workerIds.forEach(function(wid) {
 			cluster.workers[wid].send({
-				text: 'shutdown',
+				type: 'shutdown',
 				from: 'master'
 			});
 


### PR DESCRIPTION
When the master restarts workers it sends a message with 'text' field as 'shutdown', but the worker is expecting a 'type' field.